### PR TITLE
Remove Brahms as an alternative for "Finale"

### DIFF
--- a/_data/linux_alternatives.yaml
+++ b/_data/linux_alternatives.yaml
@@ -388,9 +388,6 @@
 ## Finale
 
 - linux_alternatives:
-    Brahms: &LinuxBrahms
-      internal_link: Brahms.html
-      url: http://brahms.sourceforge.net/
     Denemo: &LinuxDenemo
       internal_link: Denemo.html
       url: http://denemo.sourceforge.net/index.html


### PR DESCRIPTION
I looked at the [Brahms website](http://brahms.sourceforge.net/), and it does not appear to be music creation software. Its own documentation suggests it is an alternative to Labview.
