### PR TITLE
Add XnView as main alternative to ACDSEE

### DIFF
--- a/_data/linux_alternatives.yaml
+++ b/_data/linux_alternatives.yaml
@@ -38,6 +38,8 @@
 ## ACDSee
 
 - linux_alternatives:
+    XnView MP: &LinuxXnViewMP
+      url: https://www.xnview.com/en/xnviewmp/
     Eye of GNOME: &LinuxEyeofGNOME
       internal_link: Eye_of_GNOME.html
       url: https://wiki.gnome.org/Apps/EyeOfGnome


### PR DESCRIPTION
This is the closest alternative feature-wise and UX-wise to what ACDSEE offers. 
Citing XnView Site: 
"XnView MP is [...] a powerful picture viewer, browser and converter for Windows, Mac and Linux. This software can read more than 500 formats change picture size, reduce picture file size and much more!"
"XnView MP is provided as FREEWARE (NO Adware, NO Spyware) for private or educational use (including non-profit organizations)."
Please add an internal page for it so it can be linked as internal url also. 


